### PR TITLE
improve handling for abandoned cart email if no email set

### DIFF
--- a/activities.go
+++ b/activities.go
@@ -49,6 +49,9 @@ func (a *Activities) CreateStripeCharge(_ context.Context, cart CartState) error
 }
 
 func (a *Activities) SendAbandonedCartEmail(_ context.Context, email string) error {
+	if email == "" {
+		return nil
+	}
 	mg := mailgun.NewMailgun(a.MailgunDomain, a.MailgunKey)
 	m := mg.NewMessage(
 		"noreply@"+a.MailgunDomain,

--- a/workflow.go
+++ b/workflow.go
@@ -91,6 +91,7 @@ func CartWorkflow(ctx workflow.Context, state CartState) error {
 			}
 
 			state.Email = message.Email
+			sentAbandonedCartEmail = false
 		})
 
 		selector.AddReceive(checkoutChannel, func(c workflow.ReceiveChannel, _ bool) {


### PR DESCRIPTION
Fix #34

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Make `SendAbandonedCartEmail` avoid trying to send an email to an empty string "". `Email` is an empty string by default, and #34 correctly points out that this triggers infinite retries.

I tried to implement it so that `SendAbandonedCartEmail()` isn't called if `state.Email` is empty, but that triggers [this test error](https://stackoverflow.com/questions/47510225/error-the-code-you-are-testing-needs-to-make-1-more-calls-in-testify-package). I'm not sure how to get the Testify mock package to not error out if a mock is not called.

I also made it so that the cart workflow will resend the abandoned cart email if the email address changes. This is for cases when the user abandons their cart and updates their email later.

## Why?
<!-- Tell your future self why have you made these changes -->

Sample app shouldn't have any obvious bugs, and this is a relatively easy one to fix.

## Checklist
<!--- add/delete as needed --->

1. Closes #34

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Added test case

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

No